### PR TITLE
fix: pronoun for she

### DIFF
--- a/vervet/vervet.go
+++ b/vervet/vervet.go
@@ -158,7 +158,7 @@ func ShowYubiKey(sn string) error {
 	case 0x31:
 		PrintKV("Pronoun", "he")
 	case 0x32:
-		PrintKV("Pronoun", "he")
+		PrintKV("Pronoun", "she")
 	case 0x39:
 		PrintKV("Pronoun", "they")
 	}


### PR DESCRIPTION
Running `vervet show yubikey <serial number>` displays the "pronoun" set on the Yubikey by the user:

````
$ vervet show yubikey 12345678
========== YubiKey Status ==========
Reader ......................: Yubico YubiKey OTP+FIDO+CCID
<--snip-->
Pronoun .....................: he
<--snip-->
````

The PrintKV to display the pronoun "`she`" is missing the `s` in line 161 of ververt/vervet.go, resulting in `he` being displayed. This pull request adds the missing "s" to "she" to correct display the pronoun in output.

With this change the output correctly displays `she` when OpenPGP card is set to `Ms`:
````
$ vervet show yubikey 12345678
========== YubiKey Status ==========
Reader ......................: Yubico YubiKey OTP+FIDO+CCID
<--snip-->
Pronoun .....................: she
<--snip-->
````

Fixes Issue #10 